### PR TITLE
fix: Remove warning about children having the same key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ const Table = ({data, padding, header, cell, skeleton}) => {
       {topLine(emptyRow)}
       {headers(headersRow)}
       {midLine(emptyRow)}
-      {intersperse(() => midLine(emptyRow))(rows)}
+      {intersperse((i) => midLine(emptyRow, i))(rows)}
       {bottomLine(emptyRow)}
     </span>
   )


### PR DESCRIPTION
Every midLines had the same key "mid", because we didn't pass the index.

Now midLines index is like "mid0", etc...