### PR TITLE
ci: make build pass

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v1
         with:
-          node-version: '13.x'
+          node-version: '18.x'
       - run: yarn install
       - run: yarn build
       - run: yarn test

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -8,7 +8,7 @@ import Table, { Header, Skeleton, Cell } from '../src'
 
 const skeleton = (v: string) => <Skeleton>{v}</Skeleton>
 const header = (v: string) => <Header>{v}</Header>
-const cell = (v: string) => <Cell>{v}</Cell>
+const cell = (v: string) => <Cell column={0}>{v}</Cell>
 
 const Custom = ({ children }: React.PropsWithChildren<{}>) => (
   <Text italic color="red">


### PR DESCRIPTION
I noticed that https://github.com/maticzav/ink-table/pull/135 was never released, but I needed that feature. While investigating I found that
1. the tests fail
2. `npx semantic-release` needs Node.js 18

This PR should fix it.