### PR TITLE
move @types/react to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "component"
   ],
   "dependencies": {
+    "@types/react": "16.14.57",
     "object-hash": "^2.0.3"
   },
   "devDependencies": {
     "@types/jest": "26.0.24",
     "@types/node": "14.18.23",
     "@types/object-hash": "1.3.4",
-    "@types/react": "16.14.57",
     "codecov": "3.8.3",
     "husky": "4.3.8",
     "ink": "3.2.0",


### PR DESCRIPTION
`@types/react` is used in the generated `index.d.ts`, it's better to put `@types/react` in dependencies instead of devDependencies as a consequence.